### PR TITLE
Fixes duplicate calls to refresh access tokens

### DIFF
--- a/Float.Core.Tests/OAuthTokens.tests.cs
+++ b/Float.Core.Tests/OAuthTokens.tests.cs
@@ -14,12 +14,25 @@ namespace Float.Core.Tests
             var duration = 10;
             var tokens = new OAuthTokens("access token", "refresh token", duration, now);
 
-
             Assert.Equal(now.AddSeconds(duration), tokens.Expires);
         }
 
         [Fact]
-        public void Serializable()
+        public void ShouldRefreshWithinTenMinutes()
+        {
+            var fifteenMinuteToken = new OAuthTokens("access token", "refresh token", 15 * 60);
+            var tenMinuteToken = new OAuthTokens("access token", "refresh token", 10 * 60);
+            var zeroMinuteToken = new OAuthTokens("access token", "refresh token", 0);
+            var expiredToken = new OAuthTokens("access token", "refresh token", -10);
+
+            Assert.False(fifteenMinuteToken.ShouldRefresh);
+            Assert.True(tenMinuteToken.ShouldRefresh);
+            Assert.True(zeroMinuteToken.ShouldRefresh);
+            Assert.True(expiredToken.ShouldRefresh);
+        }
+
+        [Fact]
+        public void SerializingRetainsExpirationDate()
         {
             var tokens = new OAuthTokens("access token", "refresh token", 1000);
             var serializedData = JsonConvert.SerializeObject(tokens);

--- a/Float.Core.Tests/OAuthTokens.tests.cs
+++ b/Float.Core.Tests/OAuthTokens.tests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Float.Core.Net;
 using Newtonsoft.Json;
 using Xunit;
@@ -20,21 +19,13 @@ namespace Float.Core.Tests
         }
 
         [Fact]
-        public async void Serializable()
+        public void Serializable()
         {
-            var tokens = new OAuthTokens("access token", "refresh token", 10*60+1);
-            Assert.False(tokens.ShouldRefresh);
+            var tokens = new OAuthTokens("access token", "refresh token", 1000);
             var serializedData = JsonConvert.SerializeObject(tokens);
-
-            // OAuthTokens are configured to proactively refresh 10 minutes before they expire.
-            // Since we've set our token time to 10 minutes and 1 second, after waiting just over
-            // one second here, the token should now think it's time to be refreshed.
-            await Task.Delay(1100);
-
             var deserializedTokens = JsonConvert.DeserializeObject<OAuthTokens>(serializedData);
 
-            Assert.True(tokens.ShouldRefresh, "The test ran too fast");
-            Assert.True(deserializedTokens.ShouldRefresh, "The deserialized token has forgotten it should be refreshed");
+            Assert.Equal(tokens.Expires, deserializedTokens.Expires);
         }
     }
 }

--- a/Float.Core.Tests/OAuthTokens.tests.cs
+++ b/Float.Core.Tests/OAuthTokens.tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Float.Core.Net;
 using Newtonsoft.Json;
 using Xunit;
@@ -7,6 +8,17 @@ namespace Float.Core.Tests
 {
     public class OAuthTokensTests
     {
+        [Fact]
+        public void ComputesExpirationDate()
+        {
+            var now = DateTime.Now;
+            var duration = 10;
+            var tokens = new OAuthTokens("access token", "refresh token", duration, now);
+
+
+            Assert.Equal(now.AddSeconds(duration), tokens.Expires);
+        }
+
         [Fact]
         public async void Serializable()
         {

--- a/Float.Core.Tests/OAuthTokens.tests.cs
+++ b/Float.Core.Tests/OAuthTokens.tests.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Float.Core.Net;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Float.Core.Tests
+{
+    public class OAuthTokensTests
+    {
+        [Fact]
+        public async void Serializable()
+        {
+            var tokens = new OAuthTokens("access token", "refresh token", 10*60+1);
+            Assert.False(tokens.ShouldRefresh);
+            var serializedData = JsonConvert.SerializeObject(tokens);
+
+            // OAuthTokens are configured to proactively refresh 10 minutes before they expire.
+            // Since we've set our token time to 10 minutes and 1 second, after waiting just over
+            // one second here, the token should now think it's time to be refreshed.
+            await Task.Delay(1100);
+
+            var deserializedTokens = JsonConvert.DeserializeObject<OAuthTokens>(serializedData);
+
+            Assert.True(tokens.ShouldRefresh, "The test ran too fast");
+            Assert.True(deserializedTokens.ShouldRefresh, "The deserialized token has forgotten it should be refreshed");
+        }
+    }
+}
+

--- a/Float.Core.Tests/RepeatableTaskContainer.tests.cs
+++ b/Float.Core.Tests/RepeatableTaskContainer.tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Float.Core.Tasks;
 using Xunit;
 
@@ -55,6 +56,45 @@ namespace Float.Core.Tests
                 );
 
             Assert.Equal(1, counter);
+        }
+
+        [Fact]
+        public async Task ReportsAsRunning()
+        {
+            var semaphore = new SemaphoreSlim(0,1);
+            var repeatableTaskContainer = new RepeatableTaskContainer(async () =>
+            {
+                await semaphore.WaitAsync();
+            });
+
+            Assert.False(repeatableTaskContainer.IsRunning);
+
+            var task = repeatableTaskContainer.Run();
+
+            Assert.True(repeatableTaskContainer.IsRunning);
+            semaphore.Release();
+            await task;
+            Assert.False(repeatableTaskContainer.IsRunning);
+        }
+
+        [Fact]
+        public async Task GenericReportsAsRunning()
+        {
+            var semaphore = new SemaphoreSlim(0, 1);
+            var repeatableTaskContainer = new RepeatableTaskContainer<string>(async () =>
+            {
+                await semaphore.WaitAsync();
+                return "test";
+            });
+
+            Assert.False(repeatableTaskContainer.IsRunning);
+
+            var task = repeatableTaskContainer.Run();
+
+            Assert.True(repeatableTaskContainer.IsRunning);
+            semaphore.Release();
+            await task;
+            Assert.False(repeatableTaskContainer.IsRunning);
         }
     }
 }

--- a/Float.Core.Tests/RepeatableTaskContainer.tests.cs
+++ b/Float.Core.Tests/RepeatableTaskContainer.tests.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading.Tasks;
+using Float.Core.Tasks;
+using Xunit;
+
+namespace Float.Core.Tests
+{
+    public class RepeatableTaskContainerTests
+    {
+        [Fact]
+        public async Task TaskRunsOnce()
+        {
+            var counter = 0;
+            var repeatableTaskContainer = new RepeatableTaskContainer(async () =>
+            {
+                counter += 1;
+                await Task.Delay(10); // Simulate a "long" running task
+            });
+
+            await Task.WhenAll(
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run)
+                );
+
+            Assert.Equal(1, counter);
+        }
+
+        [Fact]
+        public async Task GenericTaskRunsOnce()
+        {
+            var counter = 0;
+            var repeatableTaskContainer = new RepeatableTaskContainer<string>(async () =>
+            {
+                counter += 1;
+                await Task.Delay(10);
+                return "test";
+            });
+
+            await Task.WhenAll(
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run),
+                Task.Run(repeatableTaskContainer.Run)
+                );
+
+            Assert.Equal(1, counter);
+        }
+    }
+}
+

--- a/Float.Core/Net/OAuth2StrategyBase.cs
+++ b/Float.Core/Net/OAuth2StrategyBase.cs
@@ -196,7 +196,10 @@ namespace Float.Core.Net
 
             var tokens = await GetTokens().ConfigureAwait(false);
 
-            if (tokens?.ShouldRefresh == true)
+            // If the access token needs to be refreshed or we are already
+            // refreshing the access token, then we should wait here until
+            // we get a new token.
+            if (tokens?.ShouldRefresh == true || refreshTokensContainer.IsRunning)
             {
                 await refreshTokensContainer.Run().ConfigureAwait(false);
             }

--- a/Float.Core/Net/OAuthTokens.cs
+++ b/Float.Core/Net/OAuthTokens.cs
@@ -17,14 +17,15 @@ namespace Float.Core.Net
         /// <param name="accessToken">Access token.</param>
         /// <param name="refreshToken">Refresh token.</param>
         /// <param name="durationSeconds">Duration the the token is valid for.</param>
-        public OAuthTokens(string accessToken, string refreshToken, int durationSeconds)
+        /// <param name="created">The timestamp this token was created.</param>
+        public OAuthTokens(string accessToken, string refreshToken, int durationSeconds, DateTime? created = null)
         {
             if (string.IsNullOrWhiteSpace(accessToken))
             {
                 throw new InvalidStringArgumentException(nameof(accessToken));
             }
 
-            timeCreated = DateTime.Now;
+            timeCreated = created ?? DateTime.Now;
             AccessToken = accessToken;
             RefreshToken = refreshToken;
             DurationSeconds = durationSeconds;
@@ -47,6 +48,12 @@ namespace Float.Core.Net
         /// </summary>
         /// <value>The duration.</value>
         public int DurationSeconds { get; }
+
+        /// <summary>
+        /// Gets the date that this token expires.
+        /// </summary>
+        /// <value>The expiration date.</value>
+        public DateTime Expires => timeCreated.AddSeconds(DurationSeconds);
 
         /// <summary>
         /// Gets a value indicating whether the access token is expiring soon, and therefore if it should be refreshed.

--- a/Float.Core/Net/OAuthTokens.cs
+++ b/Float.Core/Net/OAuthTokens.cs
@@ -64,7 +64,7 @@ namespace Float.Core.Net
         /// Gets a value indicating whether the access token is expiring soon, and therefore if it should be refreshed.
         /// </summary>
         /// <value><c>true</c>, if token should be refreshed, <c>false</c> otherwise.</value>
-        public bool ShouldRefresh => (DateTime.Now - Created).Seconds >= DurationSeconds - ExpireSoonThresholdSeconds;
+        public bool ShouldRefresh => DateTime.Now.AddSeconds(ExpireSoonThresholdSeconds) > Expires;
 
         /// <summary>
         /// Returns a <see cref="string"/> that represents the current <see cref="OAuthTokens"/>.

--- a/Float.Core/Net/OAuthTokens.cs
+++ b/Float.Core/Net/OAuthTokens.cs
@@ -9,7 +9,6 @@ namespace Float.Core.Net
     public sealed class OAuthTokens
     {
         const int ExpireSoonThresholdSeconds = 60 * 10; // 10 minutes
-        readonly DateTime timeCreated;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OAuthTokens"/> class.
@@ -25,11 +24,17 @@ namespace Float.Core.Net
                 throw new InvalidStringArgumentException(nameof(accessToken));
             }
 
-            timeCreated = created ?? DateTime.Now;
+            Created = created ?? DateTime.Now;
             AccessToken = accessToken;
             RefreshToken = refreshToken;
             DurationSeconds = durationSeconds;
         }
+
+        /// <summary>
+        /// Gets the date this token was created.
+        /// </summary>
+        /// <value>The date the token was created.</value>
+        public DateTime Created { get; }
 
         /// <summary>
         /// Gets the access token.
@@ -53,13 +58,13 @@ namespace Float.Core.Net
         /// Gets the date that this token expires.
         /// </summary>
         /// <value>The expiration date.</value>
-        public DateTime Expires => timeCreated.AddSeconds(DurationSeconds);
+        public DateTime Expires => Created.AddSeconds(DurationSeconds);
 
         /// <summary>
         /// Gets a value indicating whether the access token is expiring soon, and therefore if it should be refreshed.
         /// </summary>
         /// <value><c>true</c>, if token should be refreshed, <c>false</c> otherwise.</value>
-        public bool ShouldRefresh => (DateTime.Now - timeCreated).Seconds >= DurationSeconds - ExpireSoonThresholdSeconds;
+        public bool ShouldRefresh => (DateTime.Now - Created).Seconds >= DurationSeconds - ExpireSoonThresholdSeconds;
 
         /// <summary>
         /// Returns a <see cref="string"/> that represents the current <see cref="OAuthTokens"/>.

--- a/Float.Core/Tasks/RepeatableTaskContainer.cs
+++ b/Float.Core/Tasks/RepeatableTaskContainer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Float.Core.Tasks
@@ -11,6 +12,7 @@ namespace Float.Core.Tasks
     public class RepeatableTaskContainer
     {
         readonly Func<Task> taskFactory;
+        readonly SemaphoreSlim semaphore = new SemaphoreSlim(1);
         Task runningTask;
 
         /// <summary>
@@ -28,10 +30,14 @@ namespace Float.Core.Tasks
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
         public async Task Run()
         {
+            // Ensure we only ever have one running instance of the task.
+            semaphore.Wait();
             if (runningTask == null)
             {
                 runningTask = taskFactory();
             }
+
+            semaphore.Release();
 
             try
             {

--- a/Float.Core/Tasks/RepeatableTaskContainer.cs
+++ b/Float.Core/Tasks/RepeatableTaskContainer.cs
@@ -25,6 +25,12 @@ namespace Float.Core.Tasks
         }
 
         /// <summary>
+        /// Gets a value indicating whether the task is currently running.
+        /// </summary>
+        /// <value><c>true</c> if the task is currently running.</value>
+        public bool IsRunning => runningTask != null;
+
+        /// <summary>
         /// Run the given function asynchronously and return the result to awaiters.
         /// </summary>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>

--- a/Float.Core/Tasks/RepeatableTaskContainer.generic.cs
+++ b/Float.Core/Tasks/RepeatableTaskContainer.generic.cs
@@ -26,6 +26,12 @@ namespace Float.Core.Tasks
         }
 
         /// <summary>
+        /// Gets a value indicating whether the task is currently running.
+        /// </summary>
+        /// <value><c>true</c> if the task is currently running.</value>
+        public bool IsRunning => runningTask != null;
+
+        /// <summary>
         /// Run the given function asynchronously and return the result to awaiters.
         /// </summary>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>

--- a/Float.Core/Tasks/RepeatableTaskContainer.generic.cs
+++ b/Float.Core/Tasks/RepeatableTaskContainer.generic.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Float.Core.Tasks
@@ -12,6 +13,7 @@ namespace Float.Core.Tasks
     public class RepeatableTaskContainer<TResult>
     {
         readonly Func<Task<TResult>> taskFactory;
+        readonly SemaphoreSlim semaphore = new SemaphoreSlim(1);
         Task<TResult> runningTask;
 
         /// <summary>
@@ -29,10 +31,14 @@ namespace Float.Core.Tasks
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
         public async Task<TResult> Run()
         {
+            // Ensure we only ever have one running instance of the task.
+            semaphore.Wait();
             if (runningTask == null)
             {
                 runningTask = taskFactory();
             }
+
+            semaphore.Release();
 
             try
             {


### PR DESCRIPTION
The logic in RepeatableTaskContainer was not fully thread safe. In practice, this meant that many simultaneous calls made to refresh an OAuth token would often result in multiple API calls being made. This typically would have undesired effects since refresh tokens can typically only be used once.

Additionally, when serializing and storing the tokens, the creation time of the tokens was not included. This meant that the expiration time was not respected.

Furthermore, the library continues to use an access token even while it is actively being refreshed. If the access token was invalid (i.e. revoked, though not expired), the library will often end up refreshing it multiple times due to continued failed requests.

This adds tests for and fixes these scenarios.