### PR TITLE
Softening version requirements

### DIFF
--- a/Float.Core/Float.Core.csproj
+++ b/Float.Core/Float.Core.csproj
@@ -29,13 +29,13 @@
     <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Float.TinCan" Version="1.0.3.29" />
+    <PackageReference Include="Float.TinCan" Version="1.0.3.*" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2515+946-sha.94acebbb4-azdo.6439792" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.1,]" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.*" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />


### PR DESCRIPTION
Implementing applications may now decide when they want to update to the latest version of Newtonsoft.JSON and Xamarin.Forms.